### PR TITLE
rename plugin to Arbitrarily Contained Anarchy

### DIFF
--- a/ArbitraryComponentAccess/Components/ACAWarningPopup.cs
+++ b/ArbitraryComponentAccess/Components/ACAWarningPopup.cs
@@ -56,7 +56,7 @@ public class ACAWarningPopup : Component
 
     private void OpenGithub(IButton button, ButtonEventData eventData)
     {
-        Uri URL = new("https://github.com/paradoxical-autumn/ArbitraryComponentAccess"); // TODO: update URL with plugin name change
+        Uri URL = new("https://github.com/paradoxical-autumn/ACA");
 
         if (base.World != Userspace.UserspaceWorld)
         {

--- a/ArbitraryComponentAccess/Components/ACAWarningPopup.cs
+++ b/ArbitraryComponentAccess/Components/ACAWarningPopup.cs
@@ -13,7 +13,7 @@ public class ACAWarningPopup : Component
     protected override void OnAttach()
     {
         base.OnAttach();
-        UIBuilder uiBuilder = RadiantUI_Panel.SetupPanel(base.Slot, "Arbitrary Component Access", new float2(1280f, 720f), pinButton: false);
+        UIBuilder uiBuilder = RadiantUI_Panel.SetupPanel(base.Slot, "Arbitrarily Contained Anarchy", new float2(1280f, 720f), pinButton: false);
         Slot slot = base.Slot;
         float3 v = slot.LocalScale;
         slot.LocalScale = v * 0.0005f;
@@ -56,7 +56,7 @@ public class ACAWarningPopup : Component
 
     private void OpenGithub(IButton button, ButtonEventData eventData)
     {
-        Uri URL = new("https://github.com/paradoxical-autumn/ArbitraryComponentAccess");
+        Uri URL = new("https://github.com/paradoxical-autumn/ArbitraryComponentAccess"); // TODO: update URL with plugin name change
 
         if (base.World != Userspace.UserspaceWorld)
         {

--- a/ArbitraryComponentAccess/UniLogPlugin.cs
+++ b/ArbitraryComponentAccess/UniLogPlugin.cs
@@ -7,18 +7,18 @@ internal static class UniLogPlugin
     public static void Log(object obj, bool stackTrace = false)
     {
         string s = (obj != null) ? obj.ToString() : "NULL";
-        UniLog.Log($"[ArbitraryComponentAccess]: {s}", stackTrace);
+        UniLog.Log($"[Arbitrarily Contained Anarchy]: {s}", stackTrace);
     }
 
     public static void Warning(object obj, bool stackTrace = false)
     {
         string s = (obj != null) ? obj.ToString() : "NULL";
-        UniLog.Warning($"[ArbitraryComponentAccess]: {s}", stackTrace);
+        UniLog.Warning($"[Arbitrarily Contained Anarchy]: {s}", stackTrace);
     }
 
     public static void Error(object obj, bool stackTrace = true)
     {
         string s = (obj != null) ? obj.ToString() : "NULL";
-        UniLog.Error($"[ArbitraryComponentAccess]: {s}", stackTrace);
+        UniLog.Error($"[Arbitrarily Contained Anarchy]: {s}", stackTrace);
     }
 }

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # Arbitrarily Contained Anarchy
-*(formerlly Arbitrary Component Access)*
+*(formerly Arbitrary Component Access)*
 
 A powerful resonite **plugin** (not a mod, [see below](#isnt-this-dangerous-for-other-people-who-dont-have-it-installed)) designed to impliment some more *dangerous* functionality into FrooxEngine. Originally starting as a simple plugin to give you Arbitrary Component Access it has since evolved into much more.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # Arbitrarily Contained Anarchy
-*(formerlly Arbitrary Componetn Access)*
+*(formerlly Arbitrary Component Access)*
+
 A powerful resonite **plugin** (not a mod, [see below](#isnt-this-dangerous-for-other-people-who-dont-have-it-installed)) designed to impliment some more *dangerous* functionality into FrooxEngine. Originally starting as a simple plugin to give you Arbitrary Component Access it has since evolved into much more.
 
 > [!CAUTION]

--- a/README.md
+++ b/README.md
@@ -1,10 +1,6 @@
-# ArbitraryComponentAccess
-A powerful resonite **plugin** (not a mod, [see below](#isnt-this-dangerous-for-other-people-who-dont-have-it-installed)) designed to give you Arbitrary Component Access.
-
-It adds ProtoFlux nodes designed to:
-- Get components from slots
-- Get fields from components
-- Convert IFields into objects
+# Arbitrarily Contained Anarchy
+*(formerlly Arbitrary Componetn Access)*
+A powerful resonite **plugin** (not a mod, [see below](#isnt-this-dangerous-for-other-people-who-dont-have-it-installed)) designed to impliment some more *dangerous* functionality into FrooxEngine. Originally starting as a simple plugin to give you Arbitrary Component Access it has since evolved into much more.
 
 > [!CAUTION]
 >
@@ -25,4 +21,4 @@ Nope! This isn't a mod. You can't just join a random session and start [ab]using
 That's probably a bug from when we were recreating namespaces. Check if there's a more recent version of the plugin and if not, report it as a bug. Make sure to clarify what fields are broken and on what components. Also, if you know what version you saved the item on that can also help!
 
 ## Why did you make this?
-We got bored. Also do NOT ask why we are manually creating the protoflux bindings.
+We got bored.


### PR DESCRIPTION
Since ACA has recently branched out into more stuff than just ACA I believe a plugin rename is in order. I've already pushed changes to the feature request template to support the new different areas of the plugin.

Any existing content would not have its namespace moved but new content should be separated into different namespaces to prevent confusion.

The already existing ones are:
- ArbitraryComponentAccess
- EngineShenanigans